### PR TITLE
Separate prod BCeID enabling process from realm creation

### DIFF
--- a/.pipeline/lib/config.js
+++ b/.pipeline/lib/config.js
@@ -45,7 +45,7 @@ const phases = {
     phase: 'prod',
     changeId,
     suffix: `-prod`,
-    instance: `${name}-prod-${changeId}`,
+    instance: `${name}-prod`,
     version: `${version}-${changeId}`,
     tag: `prod-${version}-${changeId}`,
     host: 'realm-o-matic.pathfinder.gov.bc.ca',

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ This application contains:
 - web frontend in React
 - api backend in Nodejs Express
 - record management with a private GitHub repository
+- authenticated via Pathfinder Keycloak
 
 ### Project Status
 In Development   
 
 ### Local Development
-1. Prerequisites: npm, docker and docker-compose
+1. Prerequisites: npm, docker and docker-compose, ngrok
 
 2. Install project dependencies:
 run `npm i` in both /api and /web directories
@@ -30,3 +31,7 @@ run `npm i` in both /api and /web directories
 
 4. Docker deploy using the `docker-compose.yaml`
 run `docker-compose up --build` at the root level of the repo 
+
+5. Expose frontend localhost with ngrok `npm ngrok http 3000`
+
+6. Add the ngrok url to Keycloak client's valid redirect uris to enable authentication

--- a/api/src/libs/gh-utils/gh-ops.js
+++ b/api/src/libs/gh-utils/gh-ops.js
@@ -140,23 +140,25 @@ export const getRecords = async (prState = 'all', labels = [], userId = null) =>
 };
 
 /**
- * Update the state or label of a PR
- * @param {Number} pr pull request object
+ * Update the state of the PR: merging, closing or commenting
+ * TODO: add commenting feature
+ * @param {Number} prInfo pull request metadata: number and ref branch
  * @param {Boolean} mergeAndClose is ready to merge and close PR
- * @param {String} label the label to be added
  * @param {Object} message message to comment on PR
  */
-export const updatePRState = async (pr, mergeAndClose, label, message = null) => {
-  try {
-    const { isValid, payload } = validateSchema(pr, PR_SCHEMA);
-    if (!isValid) throw Error(payload);
-    logger.info(`The request from PR ${payload.number}, returns: ${message}.`);
+export const updatePRState = async (prInfo, mergeAndClose, message = null) => {
+  try {  
     if (mergeAndClose) {
-      await mergePR(payload.number);
-      await deleteBranch(payload.branch);
-    } else await addLabel(payload.number, [label]);
+      // When PR is ready to merge and close:
+      await mergePR(prInfo.number);
+      await deleteBranch(prInfo.ref);
+    } else if (message) {
+      // rejecting the PR and post messages
+    } else {
+      // rejecting the PR, no message
+    }
   } catch (err) {
-    logger.error(`Fail to get the list of PRs: ${err.message}`);
+    logger.error(`Fail to update the PR state: ${err.message}`);
     throw err;
   }
 };

--- a/api/src/libs/gh-utils/gh-requests.js
+++ b/api/src/libs/gh-utils/gh-requests.js
@@ -76,7 +76,7 @@ export const createBranch = (branchName, base) =>
  */
 export const createFile = (file, branchName) =>
   ghHelper(
-    shared.gh.repos.createFile,
+    shared.gh.repos.createOrUpdateFile,
     {
       path: GITHUB_REQUEST.recordPath(file.name),
       message: GITHUB_REQUEST.commitMessage(file.name),

--- a/api/src/router/routes/github-webhook.js
+++ b/api/src/router/routes/github-webhook.js
@@ -113,7 +113,7 @@ router.post(
               );
               // Check if BCeID is requested, if not, close and merge:
               if (!prLabels.includes(GITHUB_LABELS.BCEID)) {
-                await updatePRState(prInfo, true, message);
+                await updatePRState(prInfo, true, prInfo.message);
               }
               break;
             // BCeID is enabled, notify Requester and Reviewer:
@@ -131,7 +131,7 @@ router.post(
                 EMAIL_TYPE_TO_PATH.BCEID_COMPLETED
               );
               // Close and merge PR:
-              await updatePRState(prInfo, true, message);
+              await updatePRState(prInfo, true, prInfo.message);
               break;
             // Realm creation failed, notify Admin:
             case GITHUB_LABELS.FAILED:
@@ -181,7 +181,7 @@ router.post(
       res.status(200).end();
     } catch (err) {
       const errCode = err.status ? err.status : 500;
-      res.status(errCode).send(`Unable to email notify user: ${err}.`);
+      res.status(errCode).send(`Unable to email notify user or close PR: ${err}.`);
     }
   })
 );

--- a/api/src/router/routes/github-webhook.js
+++ b/api/src/router/routes/github-webhook.js
@@ -25,6 +25,7 @@
 import { asyncMiddleware } from '@bcgov/common-nodejs-utils';
 import { Router } from 'express';
 import { validateSchema } from '../../libs/utils';
+import { updatePRState } from '../../libs/gh-utils/gh-ops';
 import { PR_CONTENT_SCHEMA, GITHUB_LABELS } from '../../constants/github';
 import { setMailer } from '../../libs/email-utils';
 import { EMAIL_TYPE_TO_PATH, PR_ACTIONS, EMAIL_CONTACTS } from '../../constants/email';
@@ -59,17 +60,15 @@ router.get(
  * - use octokit/webhooks/verify to test secret (headers['x-hub-signature'];)
  * 
  * if PR started: email Requester
- * if BCeID label: email Reviewer
- * if failed label: email Admin
- * if rejected label: email Requester (TBD)
- * if merged and closed: email Requester
+ * if PR labeled: email accordingly based on the label
+ * if merged and closed: email Admin for full completion
  */
 router.post(
   '/pr',
   asyncMiddleware(async (req, res) => {
     const { body } = req;
     try {
-      // eslint-disable-next-line camelcase
+      // eslint-disable-next-line camel case
       const { action, number, pull_request, label } = body;
 
       // check if pr content is valid, need to parse the content as it's string:
@@ -83,6 +82,13 @@ router.post(
         realmName: payload.realmId,
       };
 
+      const prInfo = {
+        number,
+        ref: pull_request.head.ref,
+        // Set null until enabling message feature:
+        message: null,
+      };
+
       switch (action) {
         case PR_ACTIONS.OPENED:
           // New request in progress, notify requester:
@@ -94,31 +100,39 @@ router.post(
           );
           break;
         case PR_ACTIONS.LABELED:
+          // Obtain the labels assigned to the PR
+          const prLabels = pull_request.labels.map(l => l.name);
           switch (label.name) {
             // Realm creation is finished, notify Requester:
             case GITHUB_LABELS.COMPLETED:
-                await setMailer(
-                  payload.requester.email,
-                  payload.requester,
-                  realmInfo,
-                  EMAIL_TYPE_TO_PATH.COMPLETED
-                );
-                break;
+              await setMailer(
+                payload.requester.email,
+                payload.requester,
+                realmInfo,
+                EMAIL_TYPE_TO_PATH.COMPLETED
+              );
+              // Check if BCeID is requested, if not, close and merge:
+              if (!prLabels.includes(GITHUB_LABELS.BCEID)) {
+                await updatePRState(prInfo, true, message);
+              }
+              break;
             // BCeID is enabled, notify Requester and Reviewer:
             case GITHUB_LABELS.BCEID_COMPLETED:
-                await setMailer(
-                  payload.requester.email,
-                  payload.requester,
-                  realmInfo,
-                  EMAIL_TYPE_TO_PATH.BCEID_COMPLETED
-                );
-                await setMailer(
-                  EMAIL_CONTACTS.REVIEWER.to,
-                  EMAIL_CONTACTS.REVIEWER.info,
-                  realmInfo,
-                  EMAIL_TYPE_TO_PATH.BCEID_COMPLETED
-                );
-                break;
+              await setMailer(
+                payload.requester.email,
+                payload.requester,
+                realmInfo,
+                EMAIL_TYPE_TO_PATH.BCEID_COMPLETED
+              );
+              await setMailer(
+                EMAIL_CONTACTS.REVIEWER.to,
+                EMAIL_CONTACTS.REVIEWER.info,
+                realmInfo,
+                EMAIL_TYPE_TO_PATH.BCEID_COMPLETED
+              );
+              // Close and merge PR:
+              await updatePRState(prInfo, true, message);
+              break;
             // Realm creation failed, notify Admin:
             case GITHUB_LABELS.FAILED:
               await setMailer(

--- a/api/src/router/routes/github.js
+++ b/api/src/router/routes/github.js
@@ -32,39 +32,6 @@ import { GITHUB_LABELS } from '../../constants/github';
 
 const router = new Router();
 
-// TODO: not enabling this untill able to handle the BCeID process separetly
-// /**
-//  * Update record status:
-//  * this is triggered after the KeyCloak job is done for IDIR and GitHub:
-//  * 1. if success, tag ready-for-review, send notification
-//  *   - if no BCeID label, then merge and close
-//  *   - if BCeID, send notification to reviewer
-//  * 2. if failed, tag request-failed and send notification with reason
-//  */
-// router.put(
-//   '/records/setReady/:prNumber',
-//   asyncMiddleware(async (req, res) => {
-//     const { prNumber } = req.params;
-//     const { keycloakJobResult } = req.body;
-//     try {
-//       const { status, message } = keycloakJobResult;
-//       // get PR:
-//       const pr = await getPR(prNumber);
-//       // if failed, add label with reason:
-//       if (status === 'failed') await updatePRState(pr, false, GITHUB_LABELS.FAILED, message);
-//       // if BCeID, continue:
-//       else if (pr.labels && pr.labels.includes(GITHUB_LABELS.BCEID))
-//         await updatePRState(pr, false, GITHUB_LABELS.READY, message);
-//       // if no BCeID merge and close:
-//       else await updatePRState(pr, true, null, message);
-//       res.status(204).end();
-//     } catch (err) {
-//       const errCode = err.status ? err.status : 500;
-//       res.status(errCode).send(`Unable to update the PR ${prNumber}: ${err}`);
-//     }
-//   })
-// );
-
 /**
  * BCeID approval:
  * TODO: update this flow with github PR review api

--- a/web/src/constants/github.js
+++ b/web/src/constants/github.js
@@ -65,8 +65,8 @@ export const getPrStatus = (state, merged, labels = []) => {
   const isMerged = merged ? true : false;
   switch (state) {
     case GITHUB_PR_STATUS.OPEN:
-      if (labels.includes(GITHUB_LABELS.READY)) return REQUEST_STATUS.PROCESSING;
-      else if (labels.includes(GITHUB_LABELS.BCEID_REJECTED)) return REQUEST_STATUS.REJECT;
+      if (labels.includes(GITHUB_LABELS.BCEID_REJECTED)) return REQUEST_STATUS.REJECT;
+      else if (labels.includes(GITHUB_LABELS.BCEID)) return REQUEST_STATUS.PROCESSING;
       else return REQUEST_STATUS.OPEN;
     case GITHUB_PR_STATUS.CLOSED:
       return isMerged ? REQUEST_STATUS.SUCCESS : REQUEST_STATUS.FAILED;

--- a/web/src/constants/github.js
+++ b/web/src/constants/github.js
@@ -33,7 +33,7 @@ export const REQUEST_STATUS = {
   },
   // for BCeID flow:
   PENDING: {
-    text: 'Open',
+    text: 'Pending',
     color: 'orange',
   },
   REJECT: {

--- a/web/src/constants/github.js
+++ b/web/src/constants/github.js
@@ -19,9 +19,9 @@
 //
 
 export const REQUEST_STATUS = {
-  OPEN: {
-    text: 'Open',
-    color: 'orange',
+  PROCESSING: {
+    text: 'Processing',
+    color: 'olive',
   },
   SUCCESS: {
     text: 'Success',
@@ -32,9 +32,9 @@ export const REQUEST_STATUS = {
     color: 'red',
   },
   // for BCeID flow:
-  PROCESSING: {
-    text: 'Processing',
-    color: 'olive',
+  PENDING: {
+    text: 'Open',
+    color: 'orange',
   },
   REJECT: {
     text: 'Rejected',
@@ -65,9 +65,14 @@ export const getPrStatus = (state, merged, labels = []) => {
   const isMerged = merged ? true : false;
   switch (state) {
     case GITHUB_PR_STATUS.OPEN:
-      if (labels.includes(GITHUB_LABELS.BCEID_REJECTED)) return REQUEST_STATUS.REJECT;
-      else if (labels.includes(GITHUB_LABELS.BCEID)) return REQUEST_STATUS.PROCESSING;
-      else return REQUEST_STATUS.OPEN;
+      // failed:
+      if (labels.includes(GITHUB_LABELS.FAILED)) return REQUEST_STATUS.FAILED;
+      // bceid rejected:
+      else if (labels.includes(GITHUB_LABELS.BCEID_REJECTED)) return REQUEST_STATUS.REJECT;
+      // when BCeID is requested, but not yet approved or completed, request is pending:
+      else if (labels.includes(GITHUB_LABELS.BCEID) && !labels.includes(GITHUB_LABELS.BCEID_APPROVED) && !labels.includes(GITHUB_LABELS.BCEID_COMPLETED)) return REQUEST_STATUS.PENDING;
+      // otherwise, before the PR is closed, some tasks is processing:
+      else return REQUEST_STATUS.PROCESSING;
     case GITHUB_PR_STATUS.CLOSED:
       return isMerged ? REQUEST_STATUS.SUCCESS : REQUEST_STATUS.FAILED;
     default:

--- a/web/src/containers/Home.js
+++ b/web/src/containers/Home.js
@@ -70,7 +70,7 @@ export class Home extends Component {
     } else {
       const filteredRequests = this.state.showAllRequests
         ? requests
-        : requests.filter(request => request.prState === GITHUB_PR_STATUS.OPEN);
+        : requests.filter(request => request.prState === GITHUB_PR_STATUS.PENDING);
 
       requestsList = (
         <RequestList

--- a/web/src/containers/Home.js
+++ b/web/src/containers/Home.js
@@ -7,7 +7,7 @@ import { Button, Menu, Radio } from 'semantic-ui-react';
 import styled from '@emotion/styled';
 import { TEST_IDS } from '../constants/ui';
 import { ACCESS_CONTROL } from '../constants/auth';
-import { GITHUB_PR_STATUS } from '../constants/github';
+import { REQUEST_STATUS } from '../constants/github';
 import { RequestList } from '../components/Request/RequestList';
 import { SpinLoader } from '../components/UI';
 import { getRequestsAction } from '../actionCreators';
@@ -70,7 +70,7 @@ export class Home extends Component {
     } else {
       const filteredRequests = this.state.showAllRequests
         ? requests
-        : requests.filter(request => request.prState === GITHUB_PR_STATUS.PENDING);
+        : requests.filter(request => request.prState === REQUEST_STATUS.PENDING);
 
       requestsList = (
         <RequestList

--- a/web/src/containers/ReviewRequest.js
+++ b/web/src/containers/ReviewRequest.js
@@ -75,7 +75,7 @@ export class ReviewRequest extends Component {
         title={title}
         hideAction={
           authCode !== ACCESS_CONTROL.REVIEWER_ROLE ||
-          recordStatus !== REQUEST_STATUS.OPEN ||
+          recordStatus !== REQUEST_STATUS.PENDING ||
           approveRequestCompleted ||
           approveRequestStarted
         }


### PR DESCRIPTION
Prod BCeID was enabled when a realm is created, now making that an individual process with its own triggers.

Changes:
1. based on the label added to a PR, send email notifications accordingly
2. when realm creation or prod BCeID is completed, merge and close PR, then delete the branch
