### PR TITLE
Reviewer add rejection message for BCeID requests

### DIFF
--- a/api/src/libs/gh-utils/gh-ops.js
+++ b/api/src/libs/gh-utils/gh-ops.js
@@ -145,7 +145,6 @@ export const getRecords = async (prState = 'all', labels = [], userId = null) =>
 
 /**
  * Update the state of the PR: merging, closing or commenting
- * TODO: add commenting feature
  * @param {Number} prInfo pull request metadata: number and ref branch
  * @param {Boolean} mergeAndClose is ready to merge and close PR
  * @param {Object} message message to comment on PR

--- a/api/src/libs/gh-utils/gh-ops.js
+++ b/api/src/libs/gh-utils/gh-ops.js
@@ -41,6 +41,7 @@ import {
   deleteLabel,
   mergePR,
   deleteBranch,
+  getComments,
 } from './gh-requests';
 import { prParser } from './gh-helpers';
 import { validateSchema, encodeObjectWithName, normalizeData, flattenObject } from '../utils';
@@ -105,8 +106,11 @@ export const getRequestContent = async prNumber => {
     // Flatten and normalize the content to display in the frontend:
     const flattenRecord = flattenObject(contentObject);
     const normalizedRecord = normalizeData(flattenRecord, REQUEST_TO_FORM_CONTENT);
+    // Fetch PR comments:
+    const prComments = await getComments(prNumber);
+    const commentContents = prComments.length > 0 ? prComments.map(c => c.body) : [];
     // Return the PR with the file:
-    return { ...prInfo, prContent: normalizedRecord };
+    return { ...prInfo, prContent: normalizedRecord, prComments: commentContents };
   } catch (err) {
     logger.error(`Fail to get content of PR ${prNumber}: ${err.message}`);
     throw err;

--- a/api/src/libs/gh-utils/gh-requests.js
+++ b/api/src/libs/gh-utils/gh-requests.js
@@ -172,3 +172,18 @@ export const mergePR = prNumber =>
  */
 export const deleteBranch = bName =>
   ghHelper(shared.gh.git.deleteRef, { ref: GITHUB_REQUEST.shortBranchRef(bName) }, null, false);
+
+/**
+ * Merge a pull request:
+ * @param {Number} prNumber number of PR
+ * @param {String} message body of the PR comment
+ */
+export const commentPR = (prNumber, message) =>
+  ghHelper(shared.gh.issues.createComment, { issue_number: prNumber, body: message });
+
+/**
+ * Get comments for an issue/PR:
+ * @param {Number} prNumber number of PR
+ */
+export const getComments = prNumber =>
+  ghHelper(shared.gh.issues.listComments, { issue_number: prNumber });

--- a/api/src/router/routes/github.js
+++ b/api/src/router/routes/github.js
@@ -28,6 +28,7 @@ import {
   getRequestContent,
   alterPRLabels,
 } from '../../libs/gh-utils/gh-ops';
+import { commentPR } from '../../libs/gh-utils/gh-requests';
 import { GITHUB_LABELS } from '../../constants/github';
 
 const router = new Router();
@@ -44,13 +45,13 @@ router.put(
     const { prNumber } = req.params;
     const { approvalContent } = req.body;
     try {
-      // TODO: handle rejection message
       // eslint-disable-next-line no-unused-vars
       const { isApproved, message } = approvalContent;
 
-      // Alter between labels of rejected and ready:
+      // Alter between labels of rejected and ready, added comment for rejection message:
       if (!isApproved) {
         await alterPRLabels(prNumber, GITHUB_LABELS.BCEID_APPROVED, GITHUB_LABELS.BCEID_REJECTED);
+        await commentPR(prNumber, message);
       } else {
         await alterPRLabels(prNumber, GITHUB_LABELS.BCEID_REJECTED, GITHUB_LABELS.BCEID_APPROVED);
       }
@@ -58,7 +59,7 @@ router.put(
       res.status(204).end();
     } catch (err) {
       const errCode = err.status ? err.status : 500;
-      res.status(errCode).send(`Unable to label the PR ${prNumber}: ${err}`);
+      res.status(errCode).send(`Unable to update BCeID status for the PR ${prNumber}: ${err}`);
     }
   })
 );

--- a/web/src/components/UI/CommentModal.js
+++ b/web/src/components/UI/CommentModal.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { Modal, Button, TextArea } from 'semantic-ui-react';
+import { TEST_IDS } from '../../constants/ui';
+
+const StyledModal = styled(Modal)`
+  &&& {
+    width: 400px;
+    text-align: center;
+    padding: 10px 0;
+  }
+  .content {
+    margin: 30px 10px;
+  }
+  .rejectionMessage {
+    margin: 10px;
+    width: 300px;
+    height: 200px;
+    border: 1px solid #036;
+  }
+  .ui.button {
+    color: white;
+    background-color: #036;
+  }
+  .hidden {
+    display: none !important;
+  }
+`;
+
+/**
+ * Pop up modal for comment
+ * @param {Boolean} openRejectionModal Open modal when reject
+ * @param {Function} onModalClose Action when closing the modal
+ * @param {Boolean} disabled Text field editable or not
+ * @param {Function} onMessageChange Action when updating message
+ * @param {String} message The content to display when not editing
+ */
+export const CommentModal = ({
+  openRejectionModal,
+  onModalClose,
+  disabled,
+  onMessageChange,
+  message = '',
+}) => {
+  // Submit button to submit a rejection message. If only viewing, hide the button:
+  const buttons = (
+    <div>
+      <Button onClick={() => onModalClose(false)}>Close</Button>
+      <Button onClick={() => onModalClose(true)} className={disabled ? 'hidden' : null}>
+        Submit
+      </Button>
+    </div>
+  );
+
+  const onCommentChange = (e, { value }) => onMessageChange(value);
+
+  // The comment text area, either editable or display mode:
+  const comment = (
+    <TextArea
+      placeholder="Reason for Rejection"
+      className="rejectionMessage"
+      value={message}
+      onChange={onCommentChange}
+      disabled={disabled}
+    />
+  );
+
+  const options = {
+    open: openRejectionModal,
+    closeOnEscape: true,
+    closeOnDimmerClick: false,
+    size: 'tiny',
+    dimmer: 'blurring',
+    header: 'BCeID Rejection Message',
+    content: comment,
+    actions: buttons,
+  };
+  return <StyledModal data-testid={TEST_IDS.REQUEST.REJECT_MODAL} {...options} />;
+};
+
+CommentModal.propTypes = {
+  openRejectionModal: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  message: PropTypes.string,
+};
+
+export default CommentModal;

--- a/web/src/components/UI/FormHeader.js
+++ b/web/src/components/UI/FormHeader.js
@@ -33,10 +33,19 @@ const StyledFormHeader = styled.div`
  * Generate header for form with actions
  * @param {String} title the title of form
  * @param {Boolean} hideAction if the action buttons should be hidden
+ * @param {Boolean} hideRejectionViewButton if the rejection message buttons should be hidden
  * @param {Function} onApprove action on approval
  * @param {Function} onReject action on rejection
+ * @param {Function} onViewRejection action on viewing rejection message
  */
-export const FormHeader = ({ title = 'Form', hideAction = true, onApprove, onReject }) => {
+export const FormHeader = ({
+  title = 'Form',
+  hideAction = true,
+  onApprove,
+  onReject,
+  hideRejectionViewButton = true,
+  onViewRejection,
+}) => {
   return (
     <StyledFormHeader>
       <Grid>
@@ -49,8 +58,8 @@ export const FormHeader = ({ title = 'Form', hideAction = true, onApprove, onRej
           <Grid.Column mobile={16} tablet={8} computer={9}>
             <h2>{title}</h2>
           </Grid.Column>
-          <Grid.Column className={hideAction ? 'hidden' : null} mobile={16} tablet={8} computer={4}>
-            <Button.Group>
+          <Grid.Column mobile={16} tablet={8} computer={4}>
+            <Button.Group className={hideAction ? 'hidden' : null}>
               <Button onClick={onReject} data-testid={TEST_IDS.REQUEST.REJECT}>
                 Reject
               </Button>
@@ -59,6 +68,13 @@ export const FormHeader = ({ title = 'Form', hideAction = true, onApprove, onRej
                 Approve
               </Button>
             </Button.Group>
+            <Button
+              className={hideRejectionViewButton ? 'hidden' : null}
+              onClick={onViewRejection}
+              data-testid={TEST_IDS.REQUEST.VIEW_REJECT}
+            >
+              Rejection Message
+            </Button>
           </Grid.Column>
         </Grid.Row>
       </Grid>
@@ -71,6 +87,7 @@ FormHeader.propTypes = {
   hideAction: PropTypes.bool,
   onApprove: PropTypes.func,
   onReject: PropTypes.func,
+  onViewRejection: PropTypes.func,
 };
 
 export default FormHeader;

--- a/web/src/components/UI/FormHeader.js
+++ b/web/src/components/UI/FormHeader.js
@@ -12,6 +12,8 @@ const StyledFormHeader = styled.div`
 
   color: #036;
 
+  margin-bottom: 10px;
+
   .column {
     margin-top: 15px !important;
   }

--- a/web/src/components/UI/index.js
+++ b/web/src/components/UI/index.js
@@ -5,3 +5,4 @@ export { default as Layout } from './Layout';
 export { default as SpinLoader } from './SpinLoader';
 export { default as LoaderDimmer } from './LoaderDimmer';
 export { default as PopUp } from './PopUp';
+export { default as CommentModal } from './CommentModal';

--- a/web/src/constants/ui.js
+++ b/web/src/constants/ui.js
@@ -40,7 +40,9 @@ export const TEST_IDS = {
     FORM_LIST: 'request-list',
     APPROVAL: 'request-approval',
     REJECT: 'request-rejection',
+    VIEW_REJECT: 'view-request-rejection',
     CANCEL: 'go-back',
+    REJECT_MODAL: 'reject-modal',
   },
 };
 

--- a/web/src/containers/ReviewRequest.js
+++ b/web/src/containers/ReviewRequest.js
@@ -104,10 +104,17 @@ export class ReviewRequest extends Component {
     );
 
     // Decide on the status of the request:
-    if (recordInfo && this.state.recordStatus === REQUEST_STATUS.UNKNOWN) {
-      this.setState({
-        recordStatus: getPrStatus(recordInfo.prState, recordInfo.prMerged, recordInfo.labels),
-      });
+    if (recordInfo) {
+      const currRecordInfo = getPrStatus(
+        recordInfo.prState,
+        recordInfo.prMerged,
+        recordInfo.labels
+      );
+      if (this.state.recordStatus !== currRecordInfo) {
+        this.setState({
+          recordStatus: currRecordInfo,
+        });
+      }
     }
 
     // TODO: make a component for this:


### PR DESCRIPTION
When reviewer rejects a BCeID request, they could see a popup modal to enter rejection message. Requester then could view the message.
The message is stored as a comment for the PR, only onetime rejection is expected, thus only one comment is expected. When viewing the rejection message, only displaying the first comment.

Changes:
web: modal to edit and view message
api: endpoint to comment on a PR and fetch comments from a  PR.